### PR TITLE
Add support for CB7 and CBT extensions.

### DIFF
--- a/NanaZipPackage/Package.appxmanifest
+++ b/NanaZipPackage/Package.appxmanifest
@@ -101,7 +101,9 @@
               <uap:FileType>.bz2</uap:FileType>
               <uap:FileType>.bzip2</uap:FileType>
               <uap:FileType>.cab</uap:FileType>
+              <uap:FileType>.cb7</uap:FileType>
               <uap:FileType>.cbr</uap:FileType>
+              <uap:FileType>.cbt</uap:FileType>
               <uap:FileType>.cbz</uap:FileType>
               <uap:FileType>.cpio</uap:FileType>
               <uap:FileType>.deb</uap:FileType>


### PR DESCRIPTION
Similar to CBR and CBZ, these formats, albeit less popular, are renamed 7z and TAR archives for digitized comic books.
